### PR TITLE
[Bug] 시스템 언어 인식 오류 수정

### DIFF
--- a/batteryGo/batteryGoApp.swift
+++ b/batteryGo/batteryGoApp.swift
@@ -5,7 +5,11 @@ import AppKit
 
 // 언어 감지 함수 (전역)
 func isKoreanLanguage() -> Bool {
-    Locale.current.language.languageCode?.identifier == "ko"
+    let systemLanguageCodes = UserDefaults.standard.stringArray(forKey: "AppleLanguages") ?? []
+    let systemFirstLanguageCode = systemLanguageCodes.first ?? "ko-KR"
+
+    
+    return systemFirstLanguageCode == "ko-KR"
 }
 
 @main


### PR DESCRIPTION
## 관련 이슈
- Closes #3

## 작업 내용
- macOS 시스템 언어 설정을 올바르게 인식하도록 앱 언어 설정 로직 개선
- 시스템 언어가 한국어로 설정된 경우 앱이 한국어로 표시되도록 수정

## 체크리스트
- [x] 빌드 에러 없음
- [x] 기본 동작 테스트 완료
- [x] 코드 리뷰 준비 완료
